### PR TITLE
filter posts based on page category

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -37,7 +37,9 @@ layout: default
     
     <ul class="post-list">
       {% for post in paginator.posts %}
-        {% include post-list-item.html %}
+        {% if post.categories contains page.category or page.category == null %}
+          {% include post-list-item.html %}
+        {% endif %}
       {% endfor %}
     </ul>
 


### PR DESCRIPTION
I want this so I can create multiple lists as subsections of a blog

The problem is that Jekyll is pretty rigid and seems to assume a lot about how pagination works. Doesn't seem like this will be easy with Github Pages